### PR TITLE
Updating calls to the AddPrimitivesCommand method

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/ConflateMatchCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflateMatchCommand.java
@@ -39,7 +39,7 @@ public class ConflateMatchCommand extends Command {
             List<PrimitiveData> newObjects = ConflationUtils.copyObjects(sourceDataSet, match.getReferenceObject());
 
             // FIXME: bad form to execute command in constructor, how to fix?
-            addPrimitivesCommand = new AddPrimitivesCommand(newObjects, settings.getSubjectLayer());
+            addPrimitivesCommand = new AddPrimitivesCommand(newObjects, newObjects, settings.getSubjectLayer());
             if (!addPrimitivesCommand.executeCommand())
                 throw new AssertionError();
         }

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflateUnmatchedObjectCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflateUnmatchedObjectCommand.java
@@ -31,7 +31,7 @@ public class ConflateUnmatchedObjectCommand extends Command {
 
         List<PrimitiveData> newObjects = ConflationUtils.copyObjects(sourceDataLayer.data, unmatchedObjects);
 
-        addPrimitivesCommand = new AddPrimitivesCommand(newObjects, targetDataLayer);
+        addPrimitivesCommand = new AddPrimitivesCommand(newObjects, newObjects, targetDataLayer);
     }
 
     @Override


### PR DESCRIPTION
JOSM changed this method back on May 10th. Seems like they should have left a forwarding method that just put in a null for the new parameter (which is explicitly allowed) but they didn't. 
